### PR TITLE
Improve CLI performance by deferring imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ratel-runner"
-version = "0.6.0"
+version = "0.6.1"
 description = "Utilities for building and running the Ratel finite element library"
 authors = [
     {name = "Zach Atkins",email = "zach.atkins@colorado.edu"}

--- a/src/ratel_runner/helper/config.py
+++ b/src/ratel_runner/helper/config.py
@@ -1,4 +1,3 @@
-from platform import machine
 import typer
 import json
 from pathlib import Path
@@ -6,13 +5,15 @@ from rich import print
 import os
 from typing import Annotated, Any, Callable
 from dataclasses import dataclass
-from difflib import get_close_matches
 from rich.table import Table
 from enum import Enum
 from copy import deepcopy
 from contextlib import contextmanager
 
 from .flux import machines
+from .utilities import LazyImporter
+
+difflib = LazyImporter('difflib')
 
 __all__ = ['get_app_dir', 'get', 'set', 'unset', 'get_fallback', 'app']
 
@@ -181,7 +182,7 @@ def set(key: str, value: str, machine: machines.Machine | None = None, quiet: bo
     """
     if key not in _KNOWN_KEYS.keys():
         print(f"[warn]Unknown key:[/warn] {key}")
-        similar = get_close_matches(key, _KNOWN_KEYS.keys())
+        similar = difflib.get_close_matches(key, _KNOWN_KEYS.keys())
         if len(similar):
             print(f"[warn]  Similar keys:[/warn] {' '.join(similar)}")
         raise typer.Exit(1)
@@ -211,7 +212,7 @@ def get(key: str, machine: machines.Machine | None = None, quiet: bool = True):
     if key not in _KNOWN_KEYS.keys():
         if not quiet:
             print(f"[warn]Unknown key:[/warn] {key}")
-        similar = get_close_matches(key, _KNOWN_KEYS.keys())
+        similar = difflib.get_close_matches(key, _KNOWN_KEYS.keys())
         if len(similar) and not quiet:
             print(f"[warn]  Similar keys:[/warn] {' '.join(similar)}")
         raise typer.Exit(1)

--- a/src/ratel_runner/helper/flux/flux.py
+++ b/src/ratel_runner/helper/flux/flux.py
@@ -185,6 +185,7 @@ def generate(
         'echo ""',
         'cd "$SCRATCH"',
         f'cp "{options_file}" "$SCRATCH/options.yml"',
+        f'cp "$0" "$SCRATCH/script.sh"',
         f'',
         'echo ""',
         'echo "-->Starting simulation at $(date)"',

--- a/src/ratel_runner/helper/utilities.py
+++ b/src/ratel_runner/helper/utilities.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Optional, Any
 import typer
 
 
@@ -16,3 +16,20 @@ def callback_is_set(value):
     if value is None:
         raise typer.BadParameter("Required CLI option")
     return value
+
+
+class LazyImporter:
+    """Lazy import manager for CLI applications
+
+    From yazyzw.com/optimizing-python-cli-apps-for-speed-my-top-techn/
+    """
+
+    def __init__(self, module_name: str, package: Optional[str] = None):
+        self.module_name = module_name
+        self.package = package
+        self._module = None
+
+    def __getattr__(self, name: str) -> Any:
+        if self._module is None:
+            self._module = __import__(self.module_name, fromlist=[''], level=0)
+        return getattr(self._module, name)

--- a/src/ratel_runner/mpm/sweep.py
+++ b/src/ratel_runner/mpm/sweep.py
@@ -3,7 +3,7 @@ import yaml
 import rich
 import re
 from pathlib import Path
-from typing import Annotated
+from typing import Union
 import typer
 
 __doc__ = "Load and write sweep specifications for Ratel iMPM experiments"
@@ -37,14 +37,14 @@ class ParameterRange:
         return [self.start + i * step for i in range(self.count)]
 
 
-def range_representer(dumper: yaml.Dumper, data: ParameterRange) -> str:
+def range_representer(dumper: yaml.Dumper, data: ParameterRange) -> yaml.ScalarNode:
     """
     String representation of a range in the format start:end:count.
     """
     return dumper.represent_scalar("!parameter_range", f"{data.start}:{data.end}:{data.count}")
 
 
-def range_parser(loader: yaml.Loader, node: yaml.Node) -> ParameterRange:
+def range_parser(loader: Union[yaml.Loader, yaml.FullLoader, yaml.UnsafeLoader], node) -> ParameterRange:
     """
     Parse a string in the format start:end:count into a tuple of (start, end, count).
     """

--- a/uv.lock
+++ b/uv.lock
@@ -2230,7 +2230,7 @@ wheels = [
 
 [[package]]
 name = "ratel-runner"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "typer" },


### PR DESCRIPTION
This pull request introduces several improvements to the `ratel-runner` codebase, focusing on optimizing import performance, enhancing error handling for missing dependencies, and refactoring the pole diagram plotting workflow for better modularity and robustness. The most significant changes are grouped below.

**Performance and Dependency Management Improvements:**

* Introduced a `LazyImporter` utility class in `utilities.py` to support lazy loading of optional dependencies, reducing CLI startup time and avoiding import errors when certain modules are not installed. (`src/ratel_runner/helper/utilities.py`, `src/ratel_runner/helper/config.py`, `src/ratel_runner/mpm/experiments/press_common.py`) [[1]](diffhunk://#diff-8511f2f5f86b099605fd84f8359af05605e5394e258073074c2fad1661054d11R19-R35) [[2]](diffhunk://#diff-e367059bbdcc87a2e6b81dc278bafc8661b5602091cd7ad93652a50bb038c2f2L1-R16) [[3]](diffhunk://#diff-e367059bbdcc87a2e6b81dc278bafc8661b5602091cd7ad93652a50bb038c2f2L184-R185) [[4]](diffhunk://#diff-e367059bbdcc87a2e6b81dc278bafc8661b5602091cd7ad93652a50bb038c2f2L214-R215) [[5]](diffhunk://#diff-0e2a4877292ac7e8dc662daf365a77b37f99aee84465de4ffc190b6da8df865cL6-R43)
* Added runtime checks for required modules in experiment and plotting scripts, raising informative errors if dependencies are missing and guiding users to install the necessary extras. (`src/ratel_runner/mpm/experiments/press_common.py`, `src/ratel_runner/postprocess/plot/pole_diagram.py`) [[1]](diffhunk://#diff-0e2a4877292ac7e8dc662daf365a77b37f99aee84465de4ffc190b6da8df865cL6-R43) [[2]](diffhunk://#diff-ddb45cd285d9dca4a784c690abce86d53b41c7f396a257a564b1b1352ebf7e85L1-R41)

**Pole Diagram Plotting Refactor:**

* Refactored the pole diagram plotting workflow to defer heavy imports until runtime, modularized plotting logic, and improved error messages for missing plotting dependencies. Also, updated the computation and plotting of pole figures to handle both initial and deformed states, saving separate output files and unifying color scaling. (`src/ratel_runner/postprocess/plot/pole_diagram.py`) [[1]](diffhunk://#diff-ddb45cd285d9dca4a784c690abce86d53b41c7f396a257a564b1b1352ebf7e85L1-R41) [[2]](diffhunk://#diff-ddb45cd285d9dca4a784c690abce86d53b41c7f396a257a564b1b1352ebf7e85L48-R146) [[3]](diffhunk://#diff-ddb45cd285d9dca4a784c690abce86d53b41c7f396a257a564b1b1352ebf7e85L132-R160) [[4]](diffhunk://#diff-ddb45cd285d9dca4a784c690abce86d53b41c7f396a257a564b1b1352ebf7e85L153-R179) [[5]](diffhunk://#diff-ddb45cd285d9dca4a784c690abce86d53b41c7f396a257a564b1b1352ebf7e85L162-R241)

**General Codebase Updates:**

* Updated the project version from 0.6.0 to 0.6.1 in `pyproject.toml`.
* Added a missing command in the flux job script to copy the script itself to the scratch directory. (`src/ratel_runner/helper/flux/flux.py`)
* Minor type annotation and parser improvements in sweep parameter handling. (`src/ratel_runner/mpm/sweep.py`) [[1]](diffhunk://#diff-d168be84f19af4a43ef009735e784a1d7e3b2597cce54a370699f379e33007b1L6-R6) [[2]](diffhunk://#diff-d168be84f19af4a43ef009735e784a1d7e3b2597cce54a370699f379e33007b1L40-R47)

These changes collectively improve the user experience, make the CLI tools more robust in the face of missing dependencies, and provide more informative feedback and modularity in the plotting and simulation workflows.